### PR TITLE
chore(CI): add workflow for build testing

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -15,15 +15,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+
       - name: Build
         run: cargo build --verbose --bin dsync-server
-      # - name: Run tests
-      #   run: cargo test --verbose
 
   build-client:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+
       - name: Build
         run: cargo build --verbose --bin dsync-client


### PR DESCRIPTION
Adding workflow for build testing.

I've split client & server builds into separate jobs, to get better granularity.
I'm definitely missing some caching. Would be nice if I could run both jobs sequentially on a single machine. 
