### PR TITLE
Fix not available hosts being listed by list_hosts

### DIFF
--- a/dsync-server/src/utils/mod.rs
+++ b/dsync-server/src/utils/mod.rs
@@ -58,7 +58,7 @@ pub(crate) fn discover_hosts_in_local_network(require_nmap_pass: bool) -> Option
         .lines()
         .filter(|&line| {
             println!("Parsing line: {line}");
-            return !line.contains("<incomplete>") && !line.contains("_gateway");
+            return !line.contains("incomplete") && !line.contains("_gateway");
         })
         .filter_map(|line| {
             println!("Handling line: {line}");


### PR DESCRIPTION
Initially the code has been written on Linux machine, apparently with
different `nmap` implementation. The implementation I have on mac
uses parentheses not triangle brackets.

This commit resolves the issue by making the filter "parentheses
agnostic".
