### PR TITLE
Allow for pointing to arbitrary env file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ name = "dsync-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "diesel",
  "dotenvy",
  "dsync-proto",

--- a/dsync-server/Cargo.toml
+++ b/dsync-server/Cargo.toml
@@ -18,3 +18,4 @@ diesel = { version = "2.2.0", features = [
 dsync-proto = { path = "../dsync-proto" }
 dotenvy = "0.15"
 uuid = { version = "1.17.0", features = ["v4"] }
+clap = { version = "4.5.38", features = ["derive"] }

--- a/dsync-server/readme.md
+++ b/dsync-server/readme.md
@@ -1,0 +1,15 @@
+# Db setup
+
+1. First we need `diesel_cli` installation
+
+  See [here](https://diesel.rs/guides/getting-started#installing-diesel-cli).
+  tldr: run `cargo install diesel_cli --no-default-features --features sqlite`.
+
+2. Create the database & apply migrations
+
+  Run `diesel database setup`
+
+  If this fails for reason related to `migrations` directory not existing - specify the directory
+  directly by using `--migration-dir` option:
+
+  `diesel database setup --migration-dir ./migrations`

--- a/dsync-server/src/cli.rs
+++ b/dsync-server/src/cli.rs
@@ -1,0 +1,11 @@
+//! Cli setup for the server
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(about)]
+pub(crate) struct Args {
+    pub env_file: Option<PathBuf>,
+}

--- a/dsync-server/src/cli.rs
+++ b/dsync-server/src/cli.rs
@@ -7,5 +7,9 @@ use clap::Parser;
 #[derive(Parser)]
 #[command(about)]
 pub(crate) struct Args {
+    #[arg(
+        long,
+        help = "Path to file defining the environment variables. Please note that this will NOT override existing environment variables in case of collisions."
+    )]
     pub env_file: Option<PathBuf>,
 }


### PR DESCRIPTION
- Add dependency on clap in dsync-server
- Allow for pasing --env-file arg
- Add database setup instructions do dsync-server readme
- Add help message to `env-file` option
