### PR TITLE
Use port value from run configuration instead of hardcoded value

### DIFF
--- a/dsync-server/src/server.rs
+++ b/dsync-server/src/server.rs
@@ -28,7 +28,9 @@ impl Server {
 
         self.ensure_db_record_exists(&mut connection);
 
-        let addr = "[::1]:50051".parse()?;
+        let addr_str = format!("[::1]:{}", self.run_config.port);
+
+        let addr = addr_str.parse()?;
         let client_api_instance = api::ClientApiImpl::default();
 
         log::info!("Starting server at {:?}", addr);


### PR DESCRIPTION
- Move server implementation to separate module
- Expose `db_file` cli option & use the new server implementation in main
- Use value from run_config as port
