### PR TITLE
Expose server port configuration through env file & cli arg

### DIFF
--- a/dsync-server/.env
+++ b/dsync-server/.env
@@ -1,1 +1,2 @@
 DATABASE_URL=./main.db
+SERVER_PORT=8098

--- a/dsync-server/src/cli.rs
+++ b/dsync-server/src/cli.rs
@@ -12,9 +12,16 @@ pub(crate) struct Args {
         help = "Path to file defining the environment variables. Please note that this will NOT override existing environment variables in case of collisions."
     )]
     pub env_file: Option<PathBuf>,
+
     #[arg(
         long,
         help = "Path to local db. This will overwrite DATABASE_URL env variable if set. Might be necessary to use in case of running the server binary outside of dsync-server workspace dir."
     )]
     pub db_file: Option<PathBuf>,
+
+    #[arg(
+        long,
+        help = "Port number for the server to listen on. This will overwrite SERVER_PORT env variable if set."
+    )]
+    pub port: Option<i32>,
 }

--- a/dsync-server/src/server/config.rs
+++ b/dsync-server/src/server/config.rs
@@ -1,5 +1,11 @@
 use std::path::PathBuf;
 
+pub(crate) mod keys {
+    pub const DATABASE_URL: &str = "DATABASE_URL";
+    pub const ENV_FILE: &str = "ENV_FILE";
+    pub const SERVER_PORT: &str = "SERVER_PORT";
+}
+
 /// Running configuration for the server.
 pub(crate) struct RunConfiguration {
     /// Port the server should listen on.


### PR DESCRIPTION
- Expose `port` option in cli args
- Define constants for config keys
- Use newly defined constants in main function & implement port number configuration support
- Add default port number to env file

Main function definitely requires cleanup.
