### PR TITLE
[server] Remove trailing hostnames from hostnames

### DIFF
--- a/dsync-server/src/server.rs
+++ b/dsync-server/src/server.rs
@@ -74,7 +74,9 @@ impl Server {
             .output()
             .expect("Error while running hostname command");
         let output_string = String::from_utf8(hostname_output.stdout)
-            .expect("Failed to convert hostname command output to string");
+            .expect("Failed to convert hostname command output to string")
+            .trim()
+            .to_string();
         return anyhow::Ok(output_string);
     }
 }


### PR DESCRIPTION
We resolve the hostname of a local host by running the `hostname`
program & reading its output. Turns out this output contains
trailing newline sign. We need to get rid of this here,
or otherwise handling (e.g. printing) hostnames everywhere in the
program becomes quite challenging.
