### PR TITLE
[server,cli,proto,docs] Add first implementation of AddFile command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "log",
  "log4rs",
  "prost",
+ "sha1_smol",
  "thiserror 2.0.12",
  "tokio",
  "tonic",
@@ -1373,6 +1374,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "shlex"

--- a/docs/db.md
+++ b/docs/db.md
@@ -30,4 +30,26 @@ The same schema as for `peer_base_info`.
 
 # Synced paths data
 
-TODO
+Basically what I need to store for each file is for the local paths:
+
+1. **Absolute** file path (local!),
+2. File **content** hash (SH1 should be enough),
+3. (NOT SURE) The last modified date of the file for which SHA1 has has been computed against, (best in some absolute manner, e.g. seconds from EPOCH or something),
+4. Maybe file_uuid (look at the next table for explanation) (it might be just an usize)
+
+Then, synced files table must contain:
+
+1. peer_uuid,
+2. Some kind of identifier of a particular file (maybe path is enough, because it should be unique) or uuid?
+  Maybe I should generate UUID for each file, that is independent of its content & only servers as a source of identitiy?
+3. The identifier described above, but on the remote peer.
+
+To be honest as a identifier just an unique number is enough. It should be autoincrement, to avoid repeating the number (ignore the possibility
+of exhausting the usize).
+
+Then I should be able to do two things:
+
+1. Pull information on all files exposed by the remote peer,
+2. Pull information on whether there is anything to update (observed paths changed on remote)
+
+Another idea (for the future) is to add `push` mode, where if I change a file, the deamon notifies all the peers registered for this file (kinda webhook).

--- a/dsync-cli/src/cli/command.rs
+++ b/dsync-cli/src/cli/command.rs
@@ -1,11 +1,14 @@
 mod command_impl;
 
+use std::path::PathBuf;
+
 use clap::Subcommand;
 
 #[derive(Subcommand)]
 pub(crate) enum Commands {
     ListHosts,
     DiscoverHosts,
+    AddFile { file_path: PathBuf },
 }
 
 impl Commands {
@@ -13,6 +16,7 @@ impl Commands {
         match self {
             Self::ListHosts => self.handle_list_hosts().await,
             Self::DiscoverHosts => self.handle_discover_hosts().await,
+            Self::AddFile { ref file_path } => self.handle_add_file(file_path.clone()).await,
         }
     }
 }

--- a/dsync-cli/src/cli/command/command_impl.rs
+++ b/dsync-cli/src/cli/command/command_impl.rs
@@ -1,5 +1,9 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
 use dsync_proto::cli::{
-    self, DiscoverHostsRequest, ListHostsRequest, client_api_client::ClientApiClient,
+    self, AddFileRequest, DiscoverHostsRequest, ListHostsRequest,
+    client_api_client::ClientApiClient,
 };
 use prettytable::row;
 
@@ -42,6 +46,32 @@ impl Commands {
 
         let response_payload = response.into_inner();
         print_servers_info(&response_payload.servers_info);
+
+        anyhow::Ok(())
+    }
+
+    // This captures self by reference to avoid problems with dispatching,
+    // since the command itself owns the file_path.
+    pub(super) async fn handle_add_file(&self, file_path: PathBuf) -> anyhow::Result<()> {
+        let path_as_string = file_path
+            .to_str()
+            .context("Looks like the specified path is not a valid unicode")?
+            .to_string();
+
+        let file_paths: Vec<String> = vec![path_as_string];
+        let request = tonic::Request::new(AddFileRequest {
+            file_path: file_paths,
+        });
+
+        let mut client = ClientApiClient::connect(LOOPBACK_ADDR_V4).await?;
+
+        log::info!("Sending request to server");
+        log::debug!("{request:?}");
+
+        let response = client.add_file(request).await?;
+
+        log::info!("Received response from server");
+        log::debug!("{response:?}");
 
         anyhow::Ok(())
     }

--- a/dsync-cli/src/cli/command/command_impl.rs
+++ b/dsync-cli/src/cli/command/command_impl.rs
@@ -53,7 +53,18 @@ impl Commands {
     // This captures self by reference to avoid problems with dispatching,
     // since the command itself owns the file_path.
     pub(super) async fn handle_add_file(&self, file_path: PathBuf) -> anyhow::Result<()> {
-        let path_as_string = file_path
+        let file_path_abs = match file_path.canonicalize() {
+            Ok(abs_path) => abs_path,
+            Err(err) => {
+                let message = format!(
+                    "Failed to turn file_path: ${file_path:?} into absolute path with err: {err}"
+                );
+                log::error!("{message}");
+                return Err(anyhow::anyhow!(message));
+            }
+        };
+
+        let path_as_string = file_path_abs
             .to_str()
             .context("Looks like the specified path is not a valid unicode")?
             .to_string();

--- a/dsync-proto/proto-generated/cli.rs
+++ b/dsync-proto/proto-generated/cli.rs
@@ -24,6 +24,13 @@ pub struct DiscoverHostsResponse {
     #[prost(message, repeated, tag = "1")]
     pub servers_info: ::prost::alloc::vec::Vec<ServerInfo>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AddFileRequest {
+    #[prost(string, repeated, tag = "1")]
+    pub file_path: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct AddFileResponse {}
 /// Generated client implementations.
 pub mod client_api_client {
     #![allow(
@@ -160,6 +167,27 @@ pub mod client_api_client {
                 .insert(GrpcMethod::new("cli.ClientApi", "DiscoverHosts"));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn add_file(
+            &mut self,
+            request: impl tonic::IntoRequest<super::AddFileRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::AddFileResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/cli.ClientApi/AddFile");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("cli.ClientApi", "AddFile"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -189,6 +217,10 @@ pub mod client_api_server {
             tonic::Response<super::DiscoverHostsResponse>,
             tonic::Status,
         >;
+        async fn add_file(
+            &self,
+            request: tonic::Request<super::AddFileRequest>,
+        ) -> std::result::Result<tonic::Response<super::AddFileResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ClientApiServer<T> {
@@ -341,6 +373,49 @@ pub mod client_api_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = DiscoverHostsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/cli.ClientApi/AddFile" => {
+                    #[allow(non_camel_case_types)]
+                    struct AddFileSvc<T: ClientApi>(pub Arc<T>);
+                    impl<T: ClientApi> tonic::server::UnaryService<super::AddFileRequest>
+                    for AddFileSvc<T> {
+                        type Response = super::AddFileResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::AddFileRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ClientApi>::add_file(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = AddFileSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/dsync-proto/proto/cli.proto
+++ b/dsync-proto/proto/cli.proto
@@ -19,8 +19,18 @@ message DiscoverHostsResponse {
     repeated ServerInfo servers_info = 1;
 }
 
+message AddFileRequest {
+    repeated string file_path = 1;
+}
+
+message AddFileResponse {
+
+}
+
 service ClientApi {
     rpc ListHosts(ListHostsRequest) returns (ListHostsResponse);
 
     rpc DiscoverHosts(DiscoverHostsRequest) returns (DiscoverHostsResponse);
+
+    rpc AddFile(AddFileRequest) returns (AddFileResponse);
 }

--- a/dsync-server/Cargo.toml
+++ b/dsync-server/Cargo.toml
@@ -19,3 +19,4 @@ dsync-proto = { path = "../dsync-proto" }
 dotenvy = "0.15"
 uuid = { version = "1.17.0", features = ["v4"] }
 clap = { version = "4.5.38", features = ["derive"] }
+sha1_smol = "1.0.1"

--- a/dsync-server/migrations/2025-06-04-201609_create_file_storage/down.sql
+++ b/dsync-server/migrations/2025-06-04-201609_create_file_storage/down.sql
@@ -1,0 +1,1 @@
+drop table local_files;

--- a/dsync-server/migrations/2025-06-04-201609_create_file_storage/up.sql
+++ b/dsync-server/migrations/2025-06-04-201609_create_file_storage/up.sql
@@ -1,0 +1,5 @@
+create table if not exists local_files (
+    id integer not null primary key,
+    file_path text not null unique,
+    hash_sha1 text not null unique
+);

--- a/dsync-server/migrations/2025-06-04-203056_create_remote_file_storage/down.sql
+++ b/dsync-server/migrations/2025-06-04-203056_create_remote_file_storage/down.sql
@@ -1,0 +1,1 @@
+drop table synced_files;

--- a/dsync-server/migrations/2025-06-04-203056_create_remote_file_storage/up.sql
+++ b/dsync-server/migrations/2025-06-04-203056_create_remote_file_storage/up.sql
@@ -1,0 +1,5 @@
+create table if not exists synced_files (
+    local_id integer primary key,
+    peer_uuid text not null,
+    remote_file_id integer not null unique
+);

--- a/dsync-server/src/server.rs
+++ b/dsync-server/src/server.rs
@@ -16,6 +16,7 @@ pub mod config;
 pub mod database;
 pub mod global_context;
 pub mod peer_service;
+pub(self) mod util;
 
 pub(crate) struct Server {
     run_config: RunConfiguration,

--- a/dsync-server/src/server/api.rs
+++ b/dsync-server/src/server/api.rs
@@ -1,12 +1,15 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::database::models::{PeerAddrV4Row, PeerServerBaseInfoRow};
+use super::database::models::{LocalFilesWoIdRow, PeerAddrV4Row, PeerServerBaseInfoRow};
+use super::util;
 use crate::utils;
 
 use dsync_proto::cli::client_api_server::ClientApi;
 use dsync_proto::cli::{
-    self, DiscoverHostsRequest, DiscoverHostsResponse, ListHostsRequest, ListHostsResponse,
+    self, AddFileRequest, AddFileResponse, DiscoverHostsRequest, DiscoverHostsResponse,
+    ListHostsRequest, ListHostsResponse,
 };
 use dsync_proto::p2p::peer_service_client::PeerServiceClient;
 use dsync_proto::p2p::{self, HelloThereRequest};
@@ -26,6 +29,80 @@ impl ClientApiImpl {
 
 #[tonic::async_trait]
 impl ClientApi for ClientApiImpl {
+    async fn add_file(
+        &self,
+        request: Request<AddFileRequest>,
+    ) -> Result<Response<AddFileResponse>, Status> {
+        let request_payload = request.into_inner();
+
+        log::info!("Received AddFileRequest");
+        log::debug!("Payload: {request_payload:?}");
+
+        if request_payload.file_path.len() != 1 {
+            return Err(tonic::Status::invalid_argument(format!(
+                "Expected exactly 1 file. More / less is not supported right now."
+            )));
+        }
+
+        let file_path_string = request_payload
+            .file_path
+            .first()
+            .expect("Single file in array asserted above");
+
+        let file_path = match PathBuf::from(file_path_string).canonicalize() {
+            Ok(absolute_path) => absolute_path,
+            Err(err) => {
+                let message = format!(
+                    "Failed to turn path: {file_path_string} into an absolute path with err: {err}"
+                );
+                log::warn!("{message}");
+                return Err(tonic::Status::invalid_argument(message));
+            }
+        };
+
+        // 1 - verify that the file exists on the host
+        // directories are yet unsupported.
+        if !file_path.is_file() {
+            return Err(tonic::Status::invalid_argument(format!(
+                "Not a file! File from request either does not exist or is not a regular file."
+            )));
+        }
+
+        // 2 - compute file hash
+        let hash = match util::compute_sha1_hash_from_file(&file_path, None) {
+            Ok(hash) => hash,
+            Err(err) => {
+                log::warn!("Failed to compute hash for requested file with err: {err}");
+                return Err(tonic::Status::internal(format!(
+                    "Failed to compute hash for requested file with err: {err}"
+                )));
+            }
+        };
+
+        log::debug!("Hash computed for file: {hash}");
+
+        let file_abs_path_string = match file_path.to_str() {
+            Some(abs_path_str) => abs_path_str.to_string(),
+            None => {
+                log::warn!("Failed to convert absolute file path to string");
+                return Err(tonic::Status::invalid_argument(
+                    "Failed to convert absolute file path to string",
+                ));
+            }
+        };
+
+        // 3 - save file to the db
+        self.ctx
+            .db_proxy
+            .save_local_file(LocalFilesWoIdRow {
+                file_path: file_abs_path_string,
+                hash_sha1: hash,
+            })
+            .await;
+
+        return Ok(tonic::Response::new(AddFileResponse {}));
+    }
+
     async fn list_hosts(
         &self,
         _request: Request<ListHostsRequest>,

--- a/dsync-server/src/server/api.rs
+++ b/dsync-server/src/server/api.rs
@@ -49,16 +49,24 @@ impl ClientApi for ClientApiImpl {
             .first()
             .expect("Single file in array asserted above");
 
-        let file_path = match PathBuf::from(file_path_string).canonicalize() {
-            Ok(absolute_path) => absolute_path,
-            Err(err) => {
-                let message = format!(
-                    "Failed to turn path: {file_path_string} into an absolute path with err: {err}"
-                );
-                log::warn!("{message}");
-                return Err(tonic::Status::invalid_argument(message));
-            }
-        };
+        let file_path = PathBuf::from(file_path_string);
+
+        if !file_path.is_absolute() {
+            return Err(tonic::Status::invalid_argument(
+                "File path must be absolute",
+            ));
+        }
+
+        // let file_path = match PathBuf::from(file_path_string).canonicalize() {
+        //     Ok(absolute_path) => absolute_path,
+        //     Err(err) => {
+        //         let message = format!(
+        //             "Failed to turn path: {file_path_string} into an absolute path with err: {err}"
+        //         );
+        //         log::warn!("{message}");
+        //         return Err(tonic::Status::invalid_argument(message));
+        //     }
+        // };
 
         // 1 - verify that the file exists on the host
         // directories are yet unsupported.

--- a/dsync-server/src/server/database.rs
+++ b/dsync-server/src/server/database.rs
@@ -5,7 +5,7 @@ use diesel::{QueryDsl, RunQueryDsl, SelectableHelper, SqliteConnection};
 use dsync_proto::p2p;
 use thiserror::Error;
 
-use models::{LocalServerBaseInfoRow, PeerAddrV4Row, PeerServerBaseInfoRow};
+use models::{LocalFilesWoIdRow, LocalServerBaseInfoRow, PeerAddrV4Row, PeerServerBaseInfoRow};
 
 pub(crate) mod models;
 mod schema;
@@ -170,6 +170,17 @@ impl DatabaseProxy {
                 .execute(conn_ref_mut)
                 .expect("Failed to insert peer addr info to db");
         }
+    }
+
+    pub async fn save_local_file(&self, local_file: LocalFilesWoIdRow) {
+        use schema::local_files as lf;
+
+        let mut connection = self.conn.lock().await;
+        let conn_ref_mut = connection.deref_mut();
+        diesel::insert_into(lf::table)
+            .values(local_file)
+            .execute(conn_ref_mut)
+            .expect("Failed to register local file as tracked");
     }
 }
 

--- a/dsync-server/src/server/database/models.rs
+++ b/dsync-server/src/server/database/models.rs
@@ -26,3 +26,11 @@ pub struct PeerAddrV4Row {
     pub ipv4_addr: String,
     pub discovery_time: i64,
 }
+
+#[derive(Queryable, Selectable, Insertable, Clone, Debug)]
+#[diesel(table_name = super::schema::local_files)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub struct LocalFilesWoIdRow {
+    pub file_path: String,
+    pub hash_sha1: String,
+}

--- a/dsync-server/src/server/database/schema.rs
+++ b/dsync-server/src/server/database/schema.rs
@@ -32,6 +32,14 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    synced_files (local_id) {
+        local_id -> Nullable<Integer>,
+        peer_uuid -> Text,
+        remote_file_id -> Integer,
+    }
+}
+
 diesel::joinable!(peer_addr_v4 -> peer_server_base_info (uuid));
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -39,4 +47,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     local_server_base_info,
     peer_addr_v4,
     peer_server_base_info,
+    synced_files,
 );

--- a/dsync-server/src/server/database/schema.rs
+++ b/dsync-server/src/server/database/schema.rs
@@ -1,6 +1,14 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    local_files (id) {
+        id -> Integer,
+        file_path -> Text,
+        hash_sha1 -> Text,
+    }
+}
+
+diesel::table! {
     local_server_base_info (uuid) {
         uuid -> Text,
         name -> Text,
@@ -27,6 +35,7 @@ diesel::table! {
 diesel::joinable!(peer_addr_v4 -> peer_server_base_info (uuid));
 
 diesel::allow_tables_to_appear_in_same_query!(
+    local_files,
     local_server_base_info,
     peer_addr_v4,
     peer_server_base_info,

--- a/dsync-server/src/server/util.rs
+++ b/dsync-server/src/server/util.rs
@@ -1,0 +1,37 @@
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+pub(super) fn compute_sha1_hash_from_file(
+    file_path: impl AsRef<Path>,
+    buffer_read_capacity: Option<usize>,
+) -> anyhow::Result<String> {
+    let path: &Path = file_path.as_ref();
+
+    if !path.is_file() {
+        return Err(anyhow::anyhow!("Provided file_path is not a regular file"));
+    }
+
+    let mut file_handle = match std::fs::OpenOptions::new().read(true).open(path) {
+        Ok(file_handle) => file_handle,
+        Err(err) => {
+            return Err(anyhow::anyhow!(format!(
+                "Failed to open file: {path:?} with error: {err}"
+            )));
+        }
+    };
+
+    let mut sha1_instance = sha1_smol::Sha1::new();
+    let mut buffer: Vec<u8> = Vec::with_capacity(buffer_read_capacity.unwrap_or(1024));
+
+    // TODO: Will it work if the file is empty?
+    while let Ok(bytes_read) = file_handle.read(&mut buffer) {
+        if bytes_read == 0 {
+            break;
+        }
+        sha1_instance.update(&buffer[0..bytes_read]);
+    }
+
+    anyhow::Ok(sha1_instance.digest().to_string())
+}


### PR DESCRIPTION
- **Update notes on db design**
  

- **Create & run migration for `local_files` table**
  This is the table responsible for storing local files that the deamon
  exposes for syncing.
  

- **Create & run migration for creation of `synced_files` table**
  It contains data to track what file & on what host we track.
  

- **Add `AddFile` rpc to ClientApi service**
  

- **Add client implementation of `AddFile` command**
  I don't like the fact that `Command.handle_add_file` takes
  `self` by reference instead of moving it like the rest of the commands.
  This was done this way, because I need to pass down the file_path and
  this paritally moves self & I can not later call method that requires
  moving.
  
  I think that I should refactor all the methods - move the
  implementations under separate type / namespace and do not take "self"
  at all, since I do not need it.
  

- **Add dependency on sha1_smol**
  Decided to go with `sha1_smol` and not `sha1` since I do not want whole
  dependency chain.
  

- **Implement function to has a file**
  I've decided to stream the file into hashing instance instead
  of reading whole file at once, to cap potential memory usage.
  

- **Implement model & method for saving local file info to db**
  Currently this is happy-path-only implementation. No errors are handled.
  This needs to be done.
  

- **[server] First implementation of add_file server method**
  WARNING!
  
  This method currently has a bug -> e.g. when client requests to add
  `Cargo.toml` & the path is resolved to absolute path on server it might
  actually point to `.../dsync-server/Cargo.toml` instead of expected
  `.../dsync-cli/Cargo.toml`.
  
  Path must be resolved on client side!
  

- **Fix incorrect absolute path resolution**
  When path was canonicalized on server it would resolve to a file given
  cwd of current server process.
  
  Now the path is canonicalized on the client side.
  