### PR TITLE
Refactor ClientApi into UserAgentService

### DIFF
--- a/dsync-cli/src/command/file.rs
+++ b/dsync-cli/src/command/file.rs
@@ -2,8 +2,9 @@ use std::path::Path;
 
 use crate::command::utils;
 use anyhow::Context;
-use dsync_proto::cli::{
-    FileAddRequest, FileListRequest, FileRemoveRequest, client_api_client::ClientApiClient,
+use dsync_proto::user_agent::{
+    FileAddRequest, FileListRequest, FileRemoveRequest,
+    user_agent_service_client::UserAgentServiceClient,
 };
 
 use crate::command::model::LOOPBACK_ADDR_V4;
@@ -33,7 +34,7 @@ pub(crate) async fn file_add(file_path: impl AsRef<Path>) -> anyhow::Result<()> 
         group_id: None,
     });
 
-    let mut client = ClientApiClient::connect(LOOPBACK_ADDR_V4).await?;
+    let mut client = UserAgentServiceClient::connect(LOOPBACK_ADDR_V4).await?;
 
     log::info!("Sending request to server");
     log::debug!("{request:?}");
@@ -70,7 +71,7 @@ pub(crate) async fn file_remove(file_path: impl AsRef<Path>) -> anyhow::Result<(
         group_id: None,
     });
 
-    let mut client = ClientApiClient::connect(LOOPBACK_ADDR_V4).await?;
+    let mut client = UserAgentServiceClient::connect(LOOPBACK_ADDR_V4).await?;
 
     log::info!("Sending request to server");
     log::debug!("{request:?}");
@@ -99,7 +100,7 @@ pub(crate) async fn file_list(
         remote_id: None,
         group_id: None,
     });
-    let mut client = ClientApiClient::connect(LOOPBACK_ADDR_V4).await?;
+    let mut client = UserAgentServiceClient::connect(LOOPBACK_ADDR_V4).await?;
 
     log::info!("Sending request to server");
     log::debug!("{request:?}");

--- a/dsync-cli/src/command/host.rs
+++ b/dsync-cli/src/command/host.rs
@@ -1,9 +1,11 @@
-use dsync_proto::cli::{HostDiscoverRequest, HostListRequest, client_api_client::ClientApiClient};
+use dsync_proto::user_agent::{
+    HostDiscoverRequest, HostListRequest, user_agent_service_client::UserAgentServiceClient,
+};
 
 use crate::command::{model::LOOPBACK_ADDR_V4, utils};
 
 pub(crate) async fn host_list() -> anyhow::Result<()> {
-    let mut client = ClientApiClient::connect(LOOPBACK_ADDR_V4).await?;
+    let mut client = UserAgentServiceClient::connect(LOOPBACK_ADDR_V4).await?;
 
     let request = tonic::Request::new(HostListRequest { discover: false });
 
@@ -22,7 +24,7 @@ pub(crate) async fn host_list() -> anyhow::Result<()> {
 }
 
 pub(crate) async fn host_discover() -> anyhow::Result<()> {
-    let mut client = ClientApiClient::connect(LOOPBACK_ADDR_V4).await?;
+    let mut client = UserAgentServiceClient::connect(LOOPBACK_ADDR_V4).await?;
 
     let request = tonic::Request::new(HostDiscoverRequest {});
 

--- a/dsync-cli/src/command/utils.rs
+++ b/dsync-cli/src/command/utils.rs
@@ -1,4 +1,4 @@
-use dsync_proto::{cli, shared};
+use dsync_proto::{shared, user_agent};
 use prettytable::row;
 
 pub(super) fn print_servers_info(server_info_coll: &[shared::ServerInfo]) -> () {
@@ -17,7 +17,7 @@ pub(super) fn print_servers_info(server_info_coll: &[shared::ServerInfo]) -> () 
     table.printstd();
 }
 
-pub(super) fn print_local_files_desc(file_descs: &[cli::LocalFileDescription]) -> () {
+pub(super) fn print_local_files_desc(file_descs: &[user_agent::LocalFileDescription]) -> () {
     use prettytable as pt;
 
     let mut table = pt::Table::new();

--- a/dsync-proto/build.rs
+++ b/dsync-proto/build.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let proto_root_dir: PathBuf = "./proto".into();
 
-    let client_api_proto_path = proto_root_dir.join("cli.proto");
+    let user_agent_proto_path = proto_root_dir.join("user-agent.proto");
     let server_api_proto_path = proto_root_dir.join("server.proto");
     let shared_defs_proto_path = proto_root_dir.join("shared-defs.proto");
 
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .out_dir("proto-generated/")
         .compile_protos(
             &[
-                &client_api_proto_path,
+                &user_agent_proto_path,
                 &server_api_proto_path,
                 &shared_defs_proto_path,
             ],

--- a/dsync-proto/proto-generated/user_agent.rs
+++ b/dsync-proto/proto-generated/user_agent.rs
@@ -105,7 +105,7 @@ pub struct AddFileRequest {
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct AddFileResponse {}
 /// Generated client implementations.
-pub mod client_api_client {
+pub mod user_agent_service_client {
     #![allow(
         unused_variables,
         dead_code,
@@ -116,10 +116,10 @@ pub mod client_api_client {
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
-    pub struct ClientApiClient<T> {
+    pub struct UserAgentServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
-    impl ClientApiClient<tonic::transport::Channel> {
+    impl UserAgentServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
@@ -130,7 +130,7 @@ pub mod client_api_client {
             Ok(Self::new(conn))
         }
     }
-    impl<T> ClientApiClient<T>
+    impl<T> UserAgentServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
@@ -148,7 +148,7 @@ pub mod client_api_client {
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
-        ) -> ClientApiClient<InterceptedService<T, F>>
+        ) -> UserAgentServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -162,7 +162,7 @@ pub mod client_api_client {
                 http::Request<tonic::body::Body>,
             >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
-            ClientApiClient::new(InterceptedService::new(inner, interceptor))
+            UserAgentServiceClient::new(InterceptedService::new(inner, interceptor))
         }
         /// Compress requests with the given encoding.
         ///
@@ -211,9 +211,12 @@ pub mod client_api_client {
                     )
                 })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cli.ClientApi/FileAdd");
+            let path = http::uri::PathAndQuery::from_static(
+                "/user_agent.UserAgentService/FileAdd",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("cli.ClientApi", "FileAdd"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("user_agent.UserAgentService", "FileAdd"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn file_remove(
@@ -232,9 +235,12 @@ pub mod client_api_client {
                     )
                 })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cli.ClientApi/FileRemove");
+            let path = http::uri::PathAndQuery::from_static(
+                "/user_agent.UserAgentService/FileRemove",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("cli.ClientApi", "FileRemove"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("user_agent.UserAgentService", "FileRemove"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn file_list(
@@ -253,9 +259,12 @@ pub mod client_api_client {
                     )
                 })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cli.ClientApi/FileList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/user_agent.UserAgentService/FileList",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("cli.ClientApi", "FileList"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("user_agent.UserAgentService", "FileList"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn host_list(
@@ -274,9 +283,12 @@ pub mod client_api_client {
                     )
                 })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cli.ClientApi/HostList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/user_agent.UserAgentService/HostList",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("cli.ClientApi", "HostList"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("user_agent.UserAgentService", "HostList"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn host_discover(
@@ -296,11 +308,11 @@ pub mod client_api_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/cli.ClientApi/HostDiscover",
+                "/user_agent.UserAgentService/HostDiscover",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("cli.ClientApi", "HostDiscover"));
+                .insert(GrpcMethod::new("user_agent.UserAgentService", "HostDiscover"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn group_create(
@@ -320,10 +332,11 @@ pub mod client_api_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/cli.ClientApi/GroupCreate",
+                "/user_agent.UserAgentService/GroupCreate",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("cli.ClientApi", "GroupCreate"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("user_agent.UserAgentService", "GroupCreate"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn group_delete(
@@ -343,10 +356,11 @@ pub mod client_api_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/cli.ClientApi/GroupDelete",
+                "/user_agent.UserAgentService/GroupDelete",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("cli.ClientApi", "GroupDelete"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("user_agent.UserAgentService", "GroupDelete"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn group_list(
@@ -365,15 +379,18 @@ pub mod client_api_client {
                     )
                 })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/cli.ClientApi/GroupList");
+            let path = http::uri::PathAndQuery::from_static(
+                "/user_agent.UserAgentService/GroupList",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("cli.ClientApi", "GroupList"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("user_agent.UserAgentService", "GroupList"));
             self.inner.unary(req, path, codec).await
         }
     }
 }
 /// Generated server implementations.
-pub mod client_api_server {
+pub mod user_agent_service_server {
     #![allow(
         unused_variables,
         dead_code,
@@ -382,9 +399,9 @@ pub mod client_api_server {
         clippy::let_unit_value,
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with ClientApiServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with UserAgentServiceServer.
     #[async_trait]
-    pub trait ClientApi: std::marker::Send + std::marker::Sync + 'static {
+    pub trait UserAgentService: std::marker::Send + std::marker::Sync + 'static {
         async fn file_add(
             &self,
             request: tonic::Request<super::FileAddRequest>,
@@ -440,14 +457,14 @@ pub mod client_api_server {
         >;
     }
     #[derive(Debug)]
-    pub struct ClientApiServer<T> {
+    pub struct UserAgentServiceServer<T> {
         inner: Arc<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
         max_decoding_message_size: Option<usize>,
         max_encoding_message_size: Option<usize>,
     }
-    impl<T> ClientApiServer<T> {
+    impl<T> UserAgentServiceServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -498,9 +515,9 @@ pub mod client_api_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for ClientApiServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for UserAgentServiceServer<T>
     where
-        T: ClientApi,
+        T: UserAgentService,
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
@@ -515,10 +532,12 @@ pub mod client_api_server {
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             match req.uri().path() {
-                "/cli.ClientApi/FileAdd" => {
+                "/user_agent.UserAgentService/FileAdd" => {
                     #[allow(non_camel_case_types)]
-                    struct FileAddSvc<T: ClientApi>(pub Arc<T>);
-                    impl<T: ClientApi> tonic::server::UnaryService<super::FileAddRequest>
+                    struct FileAddSvc<T: UserAgentService>(pub Arc<T>);
+                    impl<
+                        T: UserAgentService,
+                    > tonic::server::UnaryService<super::FileAddRequest>
                     for FileAddSvc<T> {
                         type Response = super::FileAddResponse;
                         type Future = BoxFuture<
@@ -531,7 +550,7 @@ pub mod client_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ClientApi>::file_add(&inner, request).await
+                                <T as UserAgentService>::file_add(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -558,11 +577,11 @@ pub mod client_api_server {
                     };
                     Box::pin(fut)
                 }
-                "/cli.ClientApi/FileRemove" => {
+                "/user_agent.UserAgentService/FileRemove" => {
                     #[allow(non_camel_case_types)]
-                    struct FileRemoveSvc<T: ClientApi>(pub Arc<T>);
+                    struct FileRemoveSvc<T: UserAgentService>(pub Arc<T>);
                     impl<
-                        T: ClientApi,
+                        T: UserAgentService,
                     > tonic::server::UnaryService<super::FileRemoveRequest>
                     for FileRemoveSvc<T> {
                         type Response = super::FileRemoveResponse;
@@ -576,7 +595,7 @@ pub mod client_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ClientApi>::file_remove(&inner, request).await
+                                <T as UserAgentService>::file_remove(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -603,11 +622,11 @@ pub mod client_api_server {
                     };
                     Box::pin(fut)
                 }
-                "/cli.ClientApi/FileList" => {
+                "/user_agent.UserAgentService/FileList" => {
                     #[allow(non_camel_case_types)]
-                    struct FileListSvc<T: ClientApi>(pub Arc<T>);
+                    struct FileListSvc<T: UserAgentService>(pub Arc<T>);
                     impl<
-                        T: ClientApi,
+                        T: UserAgentService,
                     > tonic::server::UnaryService<super::FileListRequest>
                     for FileListSvc<T> {
                         type Response = super::FileListResponse;
@@ -621,7 +640,7 @@ pub mod client_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ClientApi>::file_list(&inner, request).await
+                                <T as UserAgentService>::file_list(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -648,11 +667,11 @@ pub mod client_api_server {
                     };
                     Box::pin(fut)
                 }
-                "/cli.ClientApi/HostList" => {
+                "/user_agent.UserAgentService/HostList" => {
                     #[allow(non_camel_case_types)]
-                    struct HostListSvc<T: ClientApi>(pub Arc<T>);
+                    struct HostListSvc<T: UserAgentService>(pub Arc<T>);
                     impl<
-                        T: ClientApi,
+                        T: UserAgentService,
                     > tonic::server::UnaryService<super::HostListRequest>
                     for HostListSvc<T> {
                         type Response = super::HostListResponse;
@@ -666,7 +685,7 @@ pub mod client_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ClientApi>::host_list(&inner, request).await
+                                <T as UserAgentService>::host_list(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -693,11 +712,11 @@ pub mod client_api_server {
                     };
                     Box::pin(fut)
                 }
-                "/cli.ClientApi/HostDiscover" => {
+                "/user_agent.UserAgentService/HostDiscover" => {
                     #[allow(non_camel_case_types)]
-                    struct HostDiscoverSvc<T: ClientApi>(pub Arc<T>);
+                    struct HostDiscoverSvc<T: UserAgentService>(pub Arc<T>);
                     impl<
-                        T: ClientApi,
+                        T: UserAgentService,
                     > tonic::server::UnaryService<super::HostDiscoverRequest>
                     for HostDiscoverSvc<T> {
                         type Response = super::HostDiscoverResponse;
@@ -711,7 +730,8 @@ pub mod client_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ClientApi>::host_discover(&inner, request).await
+                                <T as UserAgentService>::host_discover(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -738,11 +758,11 @@ pub mod client_api_server {
                     };
                     Box::pin(fut)
                 }
-                "/cli.ClientApi/GroupCreate" => {
+                "/user_agent.UserAgentService/GroupCreate" => {
                     #[allow(non_camel_case_types)]
-                    struct GroupCreateSvc<T: ClientApi>(pub Arc<T>);
+                    struct GroupCreateSvc<T: UserAgentService>(pub Arc<T>);
                     impl<
-                        T: ClientApi,
+                        T: UserAgentService,
                     > tonic::server::UnaryService<super::GroupCreateRequest>
                     for GroupCreateSvc<T> {
                         type Response = super::GroupCreateResponse;
@@ -756,7 +776,7 @@ pub mod client_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ClientApi>::group_create(&inner, request).await
+                                <T as UserAgentService>::group_create(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -783,11 +803,11 @@ pub mod client_api_server {
                     };
                     Box::pin(fut)
                 }
-                "/cli.ClientApi/GroupDelete" => {
+                "/user_agent.UserAgentService/GroupDelete" => {
                     #[allow(non_camel_case_types)]
-                    struct GroupDeleteSvc<T: ClientApi>(pub Arc<T>);
+                    struct GroupDeleteSvc<T: UserAgentService>(pub Arc<T>);
                     impl<
-                        T: ClientApi,
+                        T: UserAgentService,
                     > tonic::server::UnaryService<super::GroupDeleteRequest>
                     for GroupDeleteSvc<T> {
                         type Response = super::GroupDeleteResponse;
@@ -801,7 +821,7 @@ pub mod client_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ClientApi>::group_delete(&inner, request).await
+                                <T as UserAgentService>::group_delete(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -828,11 +848,11 @@ pub mod client_api_server {
                     };
                     Box::pin(fut)
                 }
-                "/cli.ClientApi/GroupList" => {
+                "/user_agent.UserAgentService/GroupList" => {
                     #[allow(non_camel_case_types)]
-                    struct GroupListSvc<T: ClientApi>(pub Arc<T>);
+                    struct GroupListSvc<T: UserAgentService>(pub Arc<T>);
                     impl<
-                        T: ClientApi,
+                        T: UserAgentService,
                     > tonic::server::UnaryService<super::GroupListRequest>
                     for GroupListSvc<T> {
                         type Response = super::GroupListResponse;
@@ -846,7 +866,7 @@ pub mod client_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ClientApi>::group_list(&inner, request).await
+                                <T as UserAgentService>::group_list(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -895,7 +915,7 @@ pub mod client_api_server {
             }
         }
     }
-    impl<T> Clone for ClientApiServer<T> {
+    impl<T> Clone for UserAgentServiceServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -908,8 +928,8 @@ pub mod client_api_server {
         }
     }
     /// Generated gRPC service name
-    pub const SERVICE_NAME: &str = "cli.ClientApi";
-    impl<T> tonic::server::NamedService for ClientApiServer<T> {
+    pub const SERVICE_NAME: &str = "user_agent.UserAgentService";
+    impl<T> tonic::server::NamedService for UserAgentServiceServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/dsync-proto/proto/user-agent-defs.proto
+++ b/dsync-proto/proto/user-agent-defs.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package cli;
+package user_agent;
 
 import "shared-defs.proto";
 

--- a/dsync-proto/proto/user-agent.proto
+++ b/dsync-proto/proto/user-agent.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
-package cli;
+package user_agent;
 
-import "cli-defs.proto";
+import "user-agent-defs.proto";
 import "shared-defs.proto";
 
 message ListHostsRequest {}
@@ -16,7 +16,7 @@ message AddFileRequest { repeated string file_path = 1; }
 
 message AddFileResponse {}
 
-service ClientApi {
+service UserAgentService {
   // File related methods
 
   rpc FileAdd(FileAddRequest) returns (FileAddResponse);

--- a/dsync-proto/src/lib.rs
+++ b/dsync-proto/src/lib.rs
@@ -5,8 +5,8 @@ pub mod shared {
     include!("../proto-generated/shared.rs");
 }
 
-pub mod cli {
-    include!("../proto-generated/cli.rs");
+pub mod user_agent {
+    include!("../proto-generated/user_agent.rs");
 }
 
 pub mod server {

--- a/dsync-server/src/main.rs
+++ b/dsync-server/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server_instance = server::Server::new(server::config::RunConfiguration {
         port: args.port.unwrap_or(server_port_env.unwrap_or(50051)),
-        database_url: std::path::PathBuf::from(database_url),
+        database_url: PathBuf::from(database_url),
         env_file_path,
     });
 

--- a/dsync-server/src/main.rs
+++ b/dsync-server/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let env_file_path_from_env = env::var(server::config::keys::ENV_FILE)
         .ok()
-        .map(|path_string| PathBuf::from(path_string));
+        .map(PathBuf::from);
 
     let env_file_path_input = args.env_file.as_ref().or(env_file_path_from_env.as_ref());
 

--- a/dsync-server/src/server.rs
+++ b/dsync-server/src/server.rs
@@ -4,7 +4,8 @@ use config::RunConfiguration;
 use database::DatabaseProxy;
 use diesel::{Connection, SqliteConnection};
 use dsync_proto::{
-    cli::client_api_server::ClientApiServer, server::peer_service_server::PeerServiceServer,
+    server::peer_service_server::PeerServiceServer,
+    user_agent::user_agent_service_server::UserAgentServiceServer,
 };
 use global_context::GlobalContext;
 use uuid::Uuid;
@@ -48,13 +49,14 @@ impl Server {
             db_proxy: Arc::new(db_proxy),
         });
 
-        let client_api_instance = service::client::ClientApiImpl::new(g_ctx.clone());
+        let user_agent_service_instance =
+            service::user_agent::UserAgentServiceImpl::new(g_ctx.clone());
         let peer_service_instance = service::peer::PeerServiceImpl::new(g_ctx.clone());
 
         log::info!("Starting server at {:?}", addr);
 
         tonic::transport::Server::builder()
-            .add_service(ClientApiServer::new(client_api_instance))
+            .add_service(UserAgentServiceServer::new(user_agent_service_instance))
             .add_service(PeerServiceServer::new(peer_service_instance))
             .serve(addr)
             .await?;

--- a/dsync-server/src/server/database.rs
+++ b/dsync-server/src/server/database.rs
@@ -34,12 +34,11 @@ impl DatabaseProxy {
             .load(db_conn.deref_mut())
             .context("Error while loading configuration");
 
-        if results.is_err() {
-            let err = results.unwrap_err();
+        if let Err(err) = results {
             return Err(LocalServerBaseInfoError::Other(err));
         }
 
-        let records = results.unwrap();
+        let mut records = results.unwrap();
 
         if records.is_empty() {
             return Err(LocalServerBaseInfoError::Uninitialized);
@@ -50,9 +49,7 @@ impl DatabaseProxy {
         }
 
         // Unwrap asserted above
-        let server_info = records[0].clone();
-
-        return Ok(server_info);
+        return Ok(records.pop().unwrap());
     }
 
     pub async fn ensure_db_record_exists(

--- a/dsync-server/src/server/service.rs
+++ b/dsync-server/src/server/service.rs
@@ -1,2 +1,2 @@
-pub(super) mod client;
 pub(super) mod peer;
+pub(super) mod user_agent;

--- a/dsync-server/src/server/service/user_agent.rs
+++ b/dsync-server/src/server/service/user_agent.rs
@@ -6,32 +6,32 @@ use crate::server::database::models::{LocalFilesWoIdRow, PeerAddrV4Row, PeerServ
 use crate::server::util;
 use crate::utils;
 
-use dsync_proto::cli::client_api_server::ClientApi;
-use dsync_proto::cli::{
+use dsync_proto::server::HelloThereRequest;
+use dsync_proto::server::peer_service_client::PeerServiceClient;
+use dsync_proto::shared;
+use dsync_proto::user_agent::user_agent_service_server::UserAgentService;
+use dsync_proto::user_agent::{
     FileAddRequest, FileAddResponse, FileListRequest, FileListResponse, FileRemoveRequest,
     FileRemoveResponse, GroupCreateRequest, GroupCreateResponse, GroupDeleteRequest,
     GroupDeleteResponse, GroupListRequest, GroupListResponse, HostDiscoverRequest,
     HostDiscoverResponse, HostListRequest, HostListResponse, LocalFileDescription,
 };
-use dsync_proto::server::HelloThereRequest;
-use dsync_proto::server::peer_service_client::PeerServiceClient;
-use dsync_proto::shared;
 use tonic::{Request, Response, Status};
 
 use crate::server::global_context::GlobalContext;
 
-pub struct ClientApiImpl {
+pub struct UserAgentServiceImpl {
     ctx: Arc<GlobalContext>,
 }
 
-impl ClientApiImpl {
+impl UserAgentServiceImpl {
     pub fn new(ctx: Arc<GlobalContext>) -> Self {
         Self { ctx }
     }
 }
 
 #[tonic::async_trait]
-impl ClientApi for ClientApiImpl {
+impl UserAgentService for UserAgentServiceImpl {
     async fn file_add(
         &self,
         request: Request<FileAddRequest>,
@@ -204,7 +204,7 @@ impl ClientApi for ClientApiImpl {
     }
 }
 
-impl ClientApiImpl {
+impl UserAgentServiceImpl {
     async fn check_hello(&self, ipv4_addr: &str) -> Option<shared::ServerInfo> {
         // Try to connect with the host
         let remote_service_socket = format!("http://{ipv4_addr}:{}", self.ctx.run_config.port);


### PR DESCRIPTION
- **Cleanup in database**
  

- **Cleanup in server::main**
  

- **More cleanup**
  

- **Refactor ClientApi service into UserAgentService service**
  This includes proto defs naming changes, module naming changes &
  service naming changes.
  
  UserAgentService makes more sense, because it is meant to support not
  only CLI client, but any agent that acts on behalf of the user.
  This is a bit web-inspired naming.
  