### PR TITLE
Refactor `fetch_peer_server_info` method

### DIFF
--- a/dsync-server/src/server/database.rs
+++ b/dsync-server/src/server/database.rs
@@ -101,14 +101,12 @@ impl DatabaseProxy {
             .expect("Failed to insert server info to db");
     }
 
-    pub async fn fetch_peer_server_info(&self) -> anyhow::Result<Vec<shared::ServerInfo>> {
+    pub async fn fetch_hosts(&self) -> anyhow::Result<Vec<shared::ServerInfo>> {
         use schema::hosts::dsl::*;
 
         let qr_result = {
             let mut connection = self.conn.lock().await;
-            QueryDsl::filter(hosts, is_remote.eq(true))
-                .select(HostsRow::as_select())
-                .load(connection.deref_mut())
+            hosts.select(HostsRow::as_select()).load(&mut *connection)
         };
 
         match qr_result {

--- a/dsync-server/src/server/service/user_agent.rs
+++ b/dsync-server/src/server/service/user_agent.rs
@@ -183,7 +183,7 @@ impl UserAgentService for UserAgentServiceImpl {
         let result = self
             .ctx
             .db_proxy
-            .fetch_peer_server_info()
+            .fetch_hosts()
             .await
             .expect("TODO: Handle this error");
 
@@ -228,7 +228,7 @@ impl UserAgentService for UserAgentServiceImpl {
     ) -> Result<Response<HostListResponse>, Status> {
         log::info!("Received ListHostsRequest");
 
-        let servers_info = match self.ctx.db_proxy.fetch_peer_server_info().await {
+        let servers_info = match self.ctx.db_proxy.fetch_hosts().await {
             Ok(data) => data,
             Err(err) => {
                 log::error!("Error while fetching peer server info: {err}");


### PR DESCRIPTION
Rename it to `fetch_hosts` & fetch not only the remote hosts, but rather
all.

I've consulted all current callers & it seems that makes sense to return
all hosts.
