### PR TITLE
Add support for XDG compliant database file location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "uuid",
+ "xdg",
 ]
 
 [[package]]
@@ -2072,6 +2073,12 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "zerocopy"

--- a/dsync-server/.env
+++ b/dsync-server/.env
@@ -1,2 +1,2 @@
-DATABASE_URL=./main.db
+# DATABASE_URL=./main.db
 SERVER_PORT=50051

--- a/dsync-server/Cargo.toml
+++ b/dsync-server/Cargo.toml
@@ -27,3 +27,4 @@ bytes = "1.10.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 async-trait = "0.1.89"
+xdg = "3.0.0"

--- a/dsync-server/src/bin/dsync-server/config.rs
+++ b/dsync-server/src/bin/dsync-server/config.rs
@@ -4,6 +4,7 @@ use dsync_server::server::config::{Config, keys::ENV_FILE};
 
 use crate::config::provider::PartialConfigProvider;
 
+pub mod error;
 pub mod provider;
 
 #[derive(Debug, Clone, Default)]

--- a/dsync-server/src/bin/dsync-server/config/error.rs
+++ b/dsync-server/src/bin/dsync-server/config/error.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigLoadError {
+    #[error("I/O error: {0}")]
+    IoError(std::io::Error),
+
+    #[error("Failed to parse config: {0}")]
+    ParseError(String),
+
+    #[error("Other error: {0}")]
+    Other(String),
+}

--- a/dsync-server/src/bin/dsync-server/config/provider.rs
+++ b/dsync-server/src/bin/dsync-server/config/provider.rs
@@ -1,79 +1,13 @@
-use std::path::PathBuf;
+use crate::config::{PartialConfig, error::ConfigLoadError};
 
-use dsync_server::server;
+mod cli_provider;
+mod env_provider;
+mod xdg_provider;
 
-use crate::{cli::Args, config::PartialConfig};
-
-#[derive(Debug, thiserror::Error)]
-pub enum ConfigLoadError {
-    #[error("I/O error: {0}")]
-    IoError(std::io::Error),
-
-    #[error("Failed to parse config: {0}")]
-    ParseError(String),
-
-    #[error("Other error: {0}")]
-    Other(String),
-}
+pub use cli_provider::CliArgsConfigProvider;
+pub use env_provider::EnvConfigProvider;
+pub use xdg_provider::XdgPartialConfigProvider;
 
 pub trait PartialConfigProvider {
     fn load_partial_config(&self) -> Result<PartialConfig, ConfigLoadError>;
-}
-
-/// EnvConfigProvider loads configuration from environment variables,
-/// but it does not load the environment itself.
-/// Assert that the environment variables are set before using this provider.
-pub struct EnvConfigProvider {}
-
-impl EnvConfigProvider {
-    pub fn new() -> Self {
-        EnvConfigProvider {}
-    }
-}
-
-impl PartialConfigProvider for EnvConfigProvider {
-    fn load_partial_config(&self) -> Result<PartialConfig, ConfigLoadError> {
-        let mut config = PartialConfig::default();
-
-        if let Ok(db_url) = dotenvy::var(server::config::keys::DATABASE_URL) {
-            let db_path = PathBuf::from(db_url);
-            config.database_url = Some(db_path);
-        }
-
-        if let Ok(server_port) = dotenvy::var(server::config::keys::SERVER_PORT) {
-            let port = server_port
-                .parse::<u16>()
-                .map_err(|err| ConfigLoadError::ParseError(err.to_string()))?;
-            config.port = Some(port);
-        }
-
-        Ok(config)
-    }
-}
-
-pub struct CliArgsConfigProvider {
-    args: Args,
-}
-
-impl CliArgsConfigProvider {
-    pub fn new(args: Args) -> Self {
-        CliArgsConfigProvider { args }
-    }
-}
-
-impl PartialConfigProvider for CliArgsConfigProvider {
-    fn load_partial_config(&self) -> Result<PartialConfig, ConfigLoadError> {
-        let mut config = PartialConfig::default();
-
-        if let Some(port) = self.args.port {
-            config.port = Some(port);
-        }
-
-        if let Some(ref database_url) = self.args.db_file {
-            let db_path = PathBuf::from(database_url);
-            config.database_url = Some(db_path);
-        }
-
-        Ok(config)
-    }
 }

--- a/dsync-server/src/bin/dsync-server/config/provider/cli_provider.rs
+++ b/dsync-server/src/bin/dsync-server/config/provider/cli_provider.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+use crate::{
+    cli::Args,
+    config::{
+        PartialConfig,
+        provider::{ConfigLoadError, PartialConfigProvider},
+    },
+};
+
+pub struct CliArgsConfigProvider {
+    args: Args,
+}
+
+impl CliArgsConfigProvider {
+    pub fn new(args: Args) -> Self {
+        CliArgsConfigProvider { args }
+    }
+}
+
+impl PartialConfigProvider for CliArgsConfigProvider {
+    fn load_partial_config(&self) -> Result<PartialConfig, ConfigLoadError> {
+        let mut config = PartialConfig::default();
+
+        if let Some(port) = self.args.port {
+            config.port = Some(port);
+        }
+
+        if let Some(ref database_url) = self.args.db_file {
+            let db_path = PathBuf::from(database_url);
+            config.database_url = Some(db_path);
+        }
+
+        Ok(config)
+    }
+}

--- a/dsync-server/src/bin/dsync-server/config/provider/env_provider.rs
+++ b/dsync-server/src/bin/dsync-server/config/provider/env_provider.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+
+use dsync_server::server;
+
+use crate::config::{
+    PartialConfig,
+    provider::{ConfigLoadError, PartialConfigProvider},
+};
+
+/// EnvConfigProvider loads configuration from environment variables,
+/// but it does not load the environment itself.
+/// Assert that the environment variables are set before using this provider.
+pub struct EnvConfigProvider {}
+
+impl EnvConfigProvider {
+    pub fn new() -> Self {
+        EnvConfigProvider {}
+    }
+}
+
+impl PartialConfigProvider for EnvConfigProvider {
+    fn load_partial_config(&self) -> Result<PartialConfig, ConfigLoadError> {
+        let mut config = PartialConfig::default();
+
+        if let Ok(db_url) = dotenvy::var(server::config::keys::DATABASE_URL) {
+            let db_path = PathBuf::from(db_url);
+            config.database_url = Some(db_path);
+        }
+
+        if let Ok(server_port) = dotenvy::var(server::config::keys::SERVER_PORT) {
+            let port = server_port
+                .parse::<u16>()
+                .map_err(|err| ConfigLoadError::ParseError(err.to_string()))?;
+            config.port = Some(port);
+        }
+
+        Ok(config)
+    }
+}

--- a/dsync-server/src/bin/dsync-server/config/provider/xdg_provider.rs
+++ b/dsync-server/src/bin/dsync-server/config/provider/xdg_provider.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use crate::config::{PartialConfig, error::ConfigLoadError, provider::PartialConfigProvider};
+
+/// This one provides only path for the database
+pub struct XdgPartialConfigProvider {}
+
+impl XdgPartialConfigProvider {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl PartialConfigProvider for XdgPartialConfigProvider {
+    fn load_partial_config(&self) -> Result<PartialConfig, ConfigLoadError> {
+        let xdg_dirs = xdg::BaseDirectories::with_prefix("dsync");
+
+        let relative_db_path = PathBuf::from("main.db");
+
+        let db_path = xdg_dirs.place_state_file(&relative_db_path);
+
+        Ok(PartialConfig::new(None, db_path.ok()))
+    }
+}

--- a/dsync-server/src/bin/dsync-server/main.rs
+++ b/dsync-server/src/bin/dsync-server/main.rs
@@ -23,8 +23,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let config = load_config(&[
-        &config::provider::CliArgsConfigProvider::new(args.clone()),
+        &config::provider::CliArgsConfigProvider::new(args),
         &config::provider::EnvConfigProvider::new(),
+        &config::provider::XdgPartialConfigProvider::new(),
     ])
     .context("Failed to load configuration")?;
 


### PR DESCRIPTION
I've added XdgPartialConfigProvider providing a stable location for the
main database file. It is still possible to indicate where the db file
should reside via CLI args or env.
