### PR TITLE
Ensure project rebuilds after modification in db migration files

### DIFF
--- a/dsync-server/build.rs
+++ b/dsync-server/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=./migrations/");
+    Ok(())
+}


### PR DESCRIPTION

Add build.rs for `dsync-server`

Previously, when only a migration file would be changed running `cargo build`
would have no effect. Now, to notify cargo that it actually need to
rebuild the project I've added `build.rs` file with appropriate
directive.
